### PR TITLE
Enable env video without decoder and log planned actions

### DIFF
--- a/plan.py
+++ b/plan.py
@@ -344,7 +344,7 @@ class PlanWorkspace:
             obs_g=self.obs_g,
             actions=actions_init,
         )
-        logs, successes, _, _ = self.evaluator.eval_actions(
+        logs, successes, _, _, plan_env_actions = self.evaluator.eval_actions(
             actions.detach(), action_len, save_video=True, filename="output_final"
         )
         logs = {f"final_eval/{k}": v for k, v in logs.items()}
@@ -359,6 +359,21 @@ class PlanWorkspace:
         }
         with open(self.log_filename, "a") as file:
             file.write(json.dumps(logs_entry) + "\n")
+
+        dataset_actions = None
+        if self.gt_actions is not None:
+            dataset_actions = self.data_preprocessor.denormalize_actions(
+                rearrange(self.gt_actions, "b t (f d) -> b (t f) d", f=self.frameskip)
+            ).cpu().numpy()
+
+        action_summary = {
+            "dataset_actions": dataset_actions.tolist() if dataset_actions is not None else None,
+            "planned_actions": plan_env_actions.tolist(),
+        }
+        with open("action_summary.json", "w") as f:
+            json.dump(action_summary, f)
+        print("Saved action summary to action_summary.json")
+
         return logs
 
 

--- a/planning/beam.py
+++ b/planning/beam.py
@@ -161,7 +161,7 @@ class BeamPlanner(BasePlanner):
       self.wandb_run.log({f"{self.logging_prefix}/loss": float(np.mean(losses_log)), "step": 1})
 
       if self.evaluator is not None:
-          logs, successes, _, _ = self.evaluator.eval_actions(
+          logs, successes, _, _, _ = self.evaluator.eval_actions(
               elite_actions, filename=f"{self.logging_prefix}_output"
           )
           logs = {f"{self.logging_prefix}/{k}": v for k, v in logs.items()}

--- a/planning/cem.py
+++ b/planning/cem.py
@@ -99,7 +99,7 @@ class CEMPlanner(BasePlanner):
             # logging
             self.wandb_run.log({f"{self.logging_prefix}/loss": float(np.mean(losses_for_logging)), "step": it + 1})
             if self.evaluator is not None and (self.eval_every > 0) and (it % self.eval_every == 0):
-                logs, successes, _, _ = self.evaluator.eval_actions(elite_actions, filename=f"{self.logging_prefix}_output_{it+1}")
+                logs, successes, _, _, _ = self.evaluator.eval_actions(elite_actions, filename=f"{self.logging_prefix}_output_{it+1}")
                 logs = {f"{self.logging_prefix}/{k}": v for k, v in logs.items()}
                 logs.update({"step": it + 1})
                 self.wandb_run.log(logs)

--- a/planning/evaluator.py
+++ b/planning/evaluator.py
@@ -127,22 +127,23 @@ class PlanEvaluator:  # evaluator for planning
         )
 
         # plot trajs
+        i_visuals = None
         if self.wm.decoder is not None:
             i_visuals = self.wm.decode_obs(i_z_obses)[0]["visual"]
             i_visuals = self._mask_traj(
                 i_visuals, action_len + 1
             )  # we have action_len + 1 states
-            e_visuals = self.preprocessor.transform_obs_visual(e_visuals)
-            e_visuals = self._mask_traj(e_visuals, action_len * self.frameskip + 1)
-            self._plot_rollout_compare(
-                e_visuals=e_visuals,
-                i_visuals=i_visuals,
-                successes=successes,
-                save_video=save_video,
-                filename=filename,
-            )
+        e_visuals = self.preprocessor.transform_obs_visual(e_visuals)
+        e_visuals = self._mask_traj(e_visuals, action_len * self.frameskip + 1)
+        self._plot_rollout_compare(
+            e_visuals=e_visuals,
+            i_visuals=i_visuals,
+            successes=successes,
+            save_video=save_video,
+            filename=filename,
+        )
 
-        return logs, successes, e_obses, e_states
+        return logs, successes, e_obses, e_states, exec_actions
 
     def _compute_rollout_metrics(self, e_state, e_obs, i_z_obs):
         """
@@ -192,75 +193,122 @@ class PlanEvaluator:  # evaluator for planning
         goal: (b, h, w, c)
         """
         e_visuals = e_visuals[: self.n_plot_samples]
-        i_visuals = i_visuals[: self.n_plot_samples]
         goal_visual = self.obs_g["visual"][: self.n_plot_samples]
         goal_visual = self.preprocessor.transform_obs_visual(goal_visual)
 
-        i_visuals = i_visuals.unsqueeze(2)
-        i_visuals = torch.cat(
-            [i_visuals] + [i_visuals] * (self.frameskip - 1),
-            dim=2,
-        )  # pad i_visuals (due to frameskip)
-        i_visuals = rearrange(i_visuals, "b t n c h w -> b (t n) c h w")
-        i_visuals = i_visuals[:, : i_visuals.shape[1] - (self.frameskip - 1)]
-
         correction = 0.3  # to distinguish env visuals and imagined visuals
 
-        if save_video:
-            for idx in range(e_visuals.shape[0]):
-                success_tag = "success" if successes[idx] else "failure"
-                frames = []
-                for i in range(e_visuals.shape[1]):
-                    e_obs = e_visuals[idx, i, ...]
-                    i_obs = i_visuals[idx, i, ...]
-                    e_obs = torch.cat(
-                        [e_obs.cpu(), goal_visual[idx, 0] - correction], dim=2
+        if i_visuals is not None:
+            i_visuals = i_visuals[: self.n_plot_samples]
+            i_visuals = i_visuals.unsqueeze(2)
+            i_visuals = torch.cat(
+                [i_visuals] + [i_visuals] * (self.frameskip - 1),
+                dim=2,
+            )  # pad i_visuals (due to frameskip)
+            i_visuals = rearrange(i_visuals, "b t n c h w -> b (t n) c h w")
+            i_visuals = i_visuals[:, : i_visuals.shape[1] - (self.frameskip - 1)]
+
+            if save_video:
+                for idx in range(e_visuals.shape[0]):
+                    success_tag = "success" if successes[idx] else "failure"
+                    frames = []
+                    for i in range(e_visuals.shape[1]):
+                        e_obs = e_visuals[idx, i, ...]
+                        i_obs = i_visuals[idx, i, ...]
+                        e_obs = torch.cat(
+                            [e_obs.cpu(), goal_visual[idx, 0] - correction], dim=2
+                        )
+                        i_obs = torch.cat(
+                            [i_obs.cpu(), goal_visual[idx, 0] - correction], dim=2
+                        )
+                        frame = torch.cat([e_obs - correction, i_obs], dim=1)
+                        frame = rearrange(frame, "c w1 w2 -> w1 w2 c")
+                        frame = rearrange(frame, "w1 w2 c -> (w1) w2 c")
+                        frame = frame.detach().cpu().numpy()
+                        frames.append(frame)
+                    video_writer = imageio.get_writer(
+                        f"{filename}_{idx}_{success_tag}.mp4", fps=12
                     )
-                    i_obs = torch.cat(
-                        [i_obs.cpu(), goal_visual[idx, 0] - correction], dim=2
+
+                    for frame in frames:
+                        frame = frame * 2 - 1 if frame.min() >= 0 else frame
+                        video_writer.append_data(
+                            (((np.clip(frame, -1, 1) + 1) / 2) * 255).astype(np.uint8)
+                        )
+                    video_writer.close()
+
+            # pad i_visuals or subsample e_visuals
+            if not self.plot_full:
+                e_visuals = e_visuals[:, :: self.frameskip]
+                i_visuals = i_visuals[:, :: self.frameskip]
+
+            n_columns = e_visuals.shape[1]
+            assert (
+                i_visuals.shape[1] == n_columns
+            ), f"Rollout lengths do not match, {e_visuals.shape[1]} and {i_visuals.shape[1]}"
+
+            # add a goal column
+            e_visuals = torch.cat([e_visuals.cpu(), goal_visual - correction], dim=1)
+            i_visuals = torch.cat([i_visuals.cpu(), goal_visual - correction], dim=1)
+            rollout = torch.cat([e_visuals.cpu() - correction, i_visuals.cpu()], dim=1)
+            n_columns += 1
+
+            imgs_for_plotting = rearrange(rollout, "b h c w1 w2 -> (b h) c w1 w2")
+            imgs_for_plotting = (
+                imgs_for_plotting * 2 - 1
+                if imgs_for_plotting.min() >= 0
+                else imgs_for_plotting
+            )
+            utils.save_image(
+                imgs_for_plotting,
+                f"{filename}.png",
+                nrow=n_columns,  # nrow is the number of columns
+                normalize=True,
+                value_range=(-1, 1),
+            )
+        else:
+            if save_video:
+                for idx in range(e_visuals.shape[0]):
+                    success_tag = "success" if successes[idx] else "failure"
+                    frames = []
+                    for i in range(e_visuals.shape[1]):
+                        e_obs = e_visuals[idx, i, ...]
+                        frame = torch.cat(
+                            [e_obs.cpu(), goal_visual[idx, 0]], dim=2
+                        )
+                        frame = rearrange(frame, "c w1 w2 -> w1 w2 c")
+                        frame = rearrange(frame, "w1 w2 c -> (w1) w2 c")
+                        frame = frame.detach().cpu().numpy()
+                        frames.append(frame)
+                    video_writer = imageio.get_writer(
+                        f"{filename}_{idx}_{success_tag}.mp4", fps=12
                     )
-                    frame = torch.cat([e_obs - correction, i_obs], dim=1)
-                    frame = rearrange(frame, "c w1 w2 -> w1 w2 c")
-                    frame = rearrange(frame, "w1 w2 c -> (w1) w2 c")
-                    frame = frame.detach().cpu().numpy()
-                    frames.append(frame)
-                video_writer = imageio.get_writer(
-                    f"{filename}_{idx}_{success_tag}.mp4", fps=12
-                )
 
-                for frame in frames:
-                    frame = frame * 2 - 1 if frame.min() >= 0 else frame
-                    video_writer.append_data(
-                        (((np.clip(frame, -1, 1) + 1) / 2) * 255).astype(np.uint8)
-                    )
-                video_writer.close()
+                    for frame in frames:
+                        frame = frame * 2 - 1 if frame.min() >= 0 else frame
+                        video_writer.append_data(
+                            (((np.clip(frame, -1, 1) + 1) / 2) * 255).astype(np.uint8)
+                        )
+                    video_writer.close()
 
-        # pad i_visuals or subsample e_visuals
-        if not self.plot_full:
-            e_visuals = e_visuals[:, :: self.frameskip]
-            i_visuals = i_visuals[:, :: self.frameskip]
+            if not self.plot_full:
+                e_visuals = e_visuals[:, :: self.frameskip]
 
-        n_columns = e_visuals.shape[1]
-        assert (
-            i_visuals.shape[1] == n_columns
-        ), f"Rollout lengths do not match, {e_visuals.shape[1]} and {i_visuals.shape[1]}"
+            n_columns = e_visuals.shape[1]
+            e_visuals = torch.cat([e_visuals.cpu(), goal_visual], dim=1)
+            rollout = e_visuals.cpu()
+            n_columns += 1
 
-        # add a goal column
-        e_visuals = torch.cat([e_visuals.cpu(), goal_visual - correction], dim=1)
-        i_visuals = torch.cat([i_visuals.cpu(), goal_visual - correction], dim=1)
-        rollout = torch.cat([e_visuals.cpu() - correction, i_visuals.cpu()], dim=1)
-        n_columns += 1
-
-        imgs_for_plotting = rearrange(rollout, "b h c w1 w2 -> (b h) c w1 w2")
-        imgs_for_plotting = (
-            imgs_for_plotting * 2 - 1
-            if imgs_for_plotting.min() >= 0
-            else imgs_for_plotting
-        )
-        utils.save_image(
-            imgs_for_plotting,
-            f"{filename}.png",
-            nrow=n_columns,  # nrow is the number of columns
-            normalize=True,
-            value_range=(-1, 1),
-        )
+            imgs_for_plotting = rearrange(rollout, "b h c w1 w2 -> (b h) c w1 w2")
+            imgs_for_plotting = (
+                imgs_for_plotting * 2 - 1
+                if imgs_for_plotting.min() >= 0
+                else imgs_for_plotting
+            )
+            utils.save_image(
+                imgs_for_plotting,
+                f"{filename}.png",
+                nrow=n_columns,
+                normalize=True,
+                value_range=(-1, 1),
+            )

--- a/planning/gd.py
+++ b/planning/gd.py
@@ -109,7 +109,7 @@ class GDPlanner(BasePlanner):
                 {f"{self.logging_prefix}/loss": total_loss.item(), "step": i + 1}
             )
             if self.evaluator is not None and i % self.eval_every == 0:
-                logs, successes, _, _ = self.evaluator.eval_actions(
+                logs, successes, _, _, _ = self.evaluator.eval_actions(
                     actions.detach(), filename=f"{self.logging_prefix}_output_{i+1}"
                 )
                 logs = {f"{self.logging_prefix}/{k}": v for k, v in logs.items()}

--- a/planning/mpc.py
+++ b/planning/mpc.py
@@ -100,7 +100,7 @@ class MPCPlanner(BasePlanner):
                 obs_0=init_obs_0,
                 state_0=init_state_0,
             )
-            logs, successes, e_obses, e_states = self.evaluator.eval_actions(
+            logs, successes, e_obses, e_states, _ = self.evaluator.eval_actions(
                 action_so_far,
                 self.action_len,
                 filename=f"plan{self.iter}",


### PR DESCRIPTION
## Summary
- always generate rollout videos using environment visuals even if the world model lacks a decoder
- record dataset actions and final executed actions to `action_summary.json`
- return executed actions from `eval_actions` and update planners accordingly

## Testing
- `python -m py_compile planning/evaluator.py plan.py planning/cem.py planning/mpc.py planning/gd.py planning/beam.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b1fff30e108320b7c1de7462683a09